### PR TITLE
Comment out unused variable.

### DIFF
--- a/protobuf-matchers/protocol-buffer-matchers.h
+++ b/protobuf-matchers/protocol-buffer-matchers.h
@@ -546,7 +546,7 @@ class ProtoMatcher : public ProtoMatcherBase {
   }
 
   virtual void DeleteExpectedProto(
-      const google::protobuf::Message* expected) const {}
+      const google::protobuf::Message* /* expected */) const {}
 
   const std::shared_ptr<const google::protobuf::Message>& expected() const {
     return expected_;


### PR DESCRIPTION
This will allow us to test with `-Werror` enabled.

Without this change we get the following error:
```
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
In file included from some/redacted/cc_test.cc:18:
external/protobuf_matchers/protobuf-matchers/protocol-buffer-matchers.h: In member function 'virtual void protobuf_matchers::internal::ProtoMatcher::DeleteExpectedProto(const google::protobuf::Message*) const':
external/protobuf_matchers/protobuf-matchers/protocol-buffer-matchers.h:549:40: error: unused parameter 'expected' [-Werror=unused-parameter]
  549 |       const google::protobuf::Message* expected) const {}
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~
cc1plus: all warnings being treated as errors
INFO: Elapsed time: 6.209s, Critical Path: 3.57s
INFO: 3 processes: 3 internal.
FAILED: Build did NOT complete successfully
```