### PR TITLE
Migrate to new Protobuf API

### DIFF
--- a/protobuf-matchers/protocol-buffer-matchers.cc
+++ b/protobuf-matchers/protocol-buffer-matchers.cc
@@ -44,13 +44,13 @@ class StringErrorCollector : public google::protobuf::io::ErrorCollector {
   explicit StringErrorCollector(std::string* error_text)
       : error_text_(error_text) {}
 
-  void AddError(int line, int column, const std::string& message) override {
+  void RecordError(int line, int column, std::string_view message) override {
     std::ostringstream stream;
     stream << line << '(' << column << "): " << message << std::endl;
     *error_text_ += stream.str();
   }
 
-  void AddWarning(int line, int column, const std::string& message) override {
+  void RecordWarning(int line, int column, std::string_view message) override {
     std::ostringstream stream;
     stream << line << '(' << column << "): " << message << std::endl;
     *error_text_ += stream.str();


### PR DESCRIPTION
`AddWarning()` and `AddError()` have been deprecated in Protobuf v22 in favor of `RecordWarning()` and `RecordError()` using `std::string_view`.

The deprecated functions have been removed in Protobuf v26. Latest stable Protobuf version as of now is v27.