### PR TITLE
Remove deprecated rules_proto package

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -15,6 +15,6 @@
 #
 
 module(name = "protobuf-matchers")
-bazel_dep(name = "protobuf", version = "23.1", repo_name = "com_google_protobuf")
+bazel_dep(name = "protobuf", version = "27.3", repo_name = "com_google_protobuf")
 bazel_dep(name = "googletest", version = "1.14.0", repo_name = "com_google_googletest")
 bazel_dep(name = "rules_cc", version = "0.0.9")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,6 +16,5 @@
 
 module(name = "protobuf-matchers")
 bazel_dep(name = "protobuf", version = "23.1", repo_name = "com_google_protobuf")
-bazel_dep(name = "googletest", version = "1.11.0", repo_name = "com_google_googletest")
+bazel_dep(name = "googletest", version = "1.14.0", repo_name = "com_google_googletest")
 bazel_dep(name = "rules_cc", version = "0.0.9")
-bazel_dep(name = "rules_proto", version = "6.0.0")

--- a/protobuf-matchers/BUILD
+++ b/protobuf-matchers/BUILD
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library", "cc_test")
 
 cc_library(

--- a/protobuf-matchers/BUILD
+++ b/protobuf-matchers/BUILD
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library", "cc_test")
-load("@rules_proto//proto:defs.bzl", "proto_library")
 
 cc_library(
     name = "protobuf-matchers",

--- a/protobuf-matchers/BUILD
+++ b/protobuf-matchers/BUILD
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-load("@protobuf//bazel:proto_library.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_proto_library", "cc_test")
 
 cc_library(


### PR DESCRIPTION
This is now included in the main protobuf package.

See https://github.com/bazelbuild/rules_proto