### PR TITLE
Fixes compatibility issue since latest protobuf uses string_view

### DIFF
--- a/protobuf-matchers/protocol-buffer-matchers.cc
+++ b/protobuf-matchers/protocol-buffer-matchers.cc
@@ -331,8 +331,10 @@ bool ProtoCompare(const internal::ProtoComparison& comp,
 // Describes the types of the expected and the actual protocol buffer.
 std::string DescribeTypes(const google::protobuf::Message& expected,
                           const google::protobuf::Message& actual) {
-  return "whose type should be " + expected.GetDescriptor()->full_name() +
-         " but actually is " + actual.GetDescriptor()->full_name();
+  return "whose type should be " + 
+         std::string(expected.GetDescriptor()->full_name()) +
+         " but actually is " + 
+         std::string(actual.GetDescriptor()->full_name());
 }
 
 // Prints the protocol buffer pointed to by proto.


### PR DESCRIPTION
Another compatibility issue with latest protobuf, as `full_name()` returns a `string_view` now, which doesn't define a + operator with `const char*`. 