### PR TITLE
Make it compatible with Protobuf 34

### DIFF
--- a/protobuf-matchers/protocol-buffer-matchers.cc
+++ b/protobuf-matchers/protocol-buffer-matchers.cc
@@ -24,6 +24,7 @@
 #include "protobuf-matchers/protocol-buffer-matchers.h"
 
 #include <algorithm>
+#include <memory>
 #include <regex>
 
 #include "gmock/gmock-matchers.h"
@@ -271,7 +272,7 @@ void SetIgnoredFieldPathsOrDie(
     const std::vector<std::string>& field_paths,
     google::protobuf::util::MessageDifferencer* differencer) {
   for (const std::string& field_path : field_paths) {
-    differencer->AddIgnoreCriteria(new IgnoreFieldPathCriteria(
+    differencer->AddIgnoreCriteria(std::make_unique<IgnoreFieldPathCriteria>(
         ParseFieldPathOrDie(field_path, root_descriptor)));
   }
 }


### PR DESCRIPTION
The method `void AddIgnoreCriteria(IgnoreCriteria* ignore_criteria)` was removed in Protobuf 34.0 and the method `void AddIgnoreCriteria(std::unique_ptr<IgnoreCriteria> ignore_criteria)` should be used.

Context: https://github.com/protocolbuffers/protobuf/commit/b115358c64127896fed88b8b5ef5d91d86d8cbae