### PR TITLE
[cmake] Set up CI job for compiling with CMake

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,9 +9,23 @@ on:
       main
 
 jobs:
-  test:
+  bazel:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
       - name: Run the tests
         run: bazel test -j 4 //...
+
+  cmake:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up CMake
+        run: |
+          cmake -S . -B build -G Ninja
+      - name: Run build
+        run: |
+          cmake --build build
+      - name: Run tests
+        run: |
+          cmake --build build --target test


### PR DESCRIPTION
~~CI will probably fail without #18 because the dependencies are not preinstalled in the Github runners.~~