### PR TITLE
[CI] Prevent doubly-executed CI jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      main
+  pull_request:
+    branches:
+      main
 
 jobs:
   test:


### PR DESCRIPTION
This PR changes the conditions for when CI jobs are triggered. The previous configuration led to double execution if you'd push to a branch that is used for a pull request. By specifying the `branches` field for `push` and `pull_request`, only one of the two conditions triggers for any new commit.