### PR TITLE
[cmake] Use project-specific option to disable tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ option(PROTOBUF_MATCHERS_FETCH_GTEST "Download GTest via FetchContent if not fou
 set(PROTOBUF_MATCHERS_GTEST_FETCH_TAG ${PROTOBUF_MATCHERS_GTEST_DEFAULT_FETCH_TAG}
     CACHE STRING "Git tag or commit to use for GTest FetchContent")
 
+option(PROTOBUF_MATCHERS_BUILD_TESTING "Build the protobuf-matchers tests" ON)
+
 # -----------------------------------------------------------------------------
 # Protobuf Dependency
 # -----------------------------------------------------------------------------
@@ -97,9 +99,9 @@ target_link_libraries(protobuf-matchers PUBLIC
     protobuf::libprotobuf
     GTest::gmock)
 
-include(CTest)
-include(GoogleTest)
-if(BUILD_TESTING)
+if(PROTOBUF_MATCHERS_BUILD_TESTING)
+    include(CTest)
+    include(GoogleTest)
     set(PROTO_BINARY_DIR "${CMAKE_CURRENT_BINARY_DIR}/generated")
     file(MAKE_DIRECTORY ${PROTO_BINARY_DIR})
     add_library(protobuf-matchers-proto OBJECT "${CMAKE_CURRENT_LIST_DIR}/protobuf-matchers/test.proto")


### PR DESCRIPTION
~~This PR is currently stacked on #19 and #18.~~

This PR replace the use of `BUILD_TESTING` with a project-specific equivalent. This allows downstream projects to disable tests for this project while still enabling tests for themselves. Also, the PR reduces the scope of two test-specific includes.