### PR TITLE
[ci] Set up caches for CMake CI job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,9 +20,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+      - name: Cache CMake FetchContent dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ github.workspace }}/build/_deps
+          key: ${{ runner.os }}-cmake-deps-poto-${{ matrix.protobuf-version }}-googletest-${{ matrix.googletest-version }}
+          restore-keys: |
+            ${{ runner.os }}-cmake-deps-
+      - name: Set up ccache
+        uses: hendrikmuhs/ccache-action@1bbbcda0748b3e340dee71a314fa68ffcbd6df79 # v1.2.21
+        with:
+          key: ${{ runner.os }}
+          max-size: 500M
       - name: Set up CMake
         run: |
-          cmake -S . -B build -G Ninja
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+            -DCMAKE_CXX_COMPILER_LAUNCHER=ccache
       - name: Run build
         run: |
           cmake --build build


### PR DESCRIPTION
~~This PR is stacked on top of #16.~~

This PR sets up ccache and CMake dependency caching for the CMake CI job. This reduces the CMake step from ~30s to ~5s and the compilation step from ~2-5m to a few seconds, brining the end-to-end time down from 3-6m to ~30s.